### PR TITLE
Add coverage workflow using vscode-test-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - npm run vscode:prepublish
 
 script:
-  - npm test
+  - npm run test:coverage
 
 after_success:
   - npm run publish-coverage

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,14 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
-    files: 'out/test/**/*.test.js',
+    tests: [
+        {
+            files: 'out/test/**/*.test.js',
+            srcDir: 'src',
+        },
+    ],
+    coverage: {
+        reporter: ['html', 'lcov', 'text-summary'],
+        output: 'coverage',
+    },
 });

--- a/package.json
+++ b/package.json
@@ -263,6 +263,8 @@
         "lint": "eslint src --ext .ts",
         "fix": "eslint --fix src --ext .ts",
         "test": "npm run compile && node ./scripts/run-vscode-test.js",
+        "test:coverage": "npm run compile && node ./scripts/run-vscode-test.js --coverage",
+        "publish-coverage": "codecov -f coverage/lcov.info",
         "generate-syntax": "node syntaxes/populate-syntax.js"
     },
     "devDependencies": {

--- a/scripts/run-vscode-test.js
+++ b/scripts/run-vscode-test.js
@@ -26,13 +26,14 @@ function run(cmd, args) {
 }
 
 const vscodeTestBin = process.platform === 'win32' ? 'vscode-test.cmd' : 'vscode-test';
+const cliArgs = process.argv.slice(2);
 
 const shouldUseXvfb =
   process.platform === 'linux' && hasCommand('xvfb-run') && !canConnectToDisplay();
 
 if (shouldUseXvfb) {
-  run('xvfb-run', ['-a', vscodeTestBin]);
+  run('xvfb-run', ['-a', vscodeTestBin, ...cliArgs]);
 } else {
-  run(vscodeTestBin, []);
+  run(vscodeTestBin, cliArgs);
 }
 


### PR DESCRIPTION
Implement code coverage measurement using `@vscode/test-cli` to replace the deprecated and vulnerable `vscode-coverage-test-runner`.

The previous `vscode-coverage-test-runner` package was removed due to being unmaintained and having a security vulnerability (Minimist dependency). This PR introduces a new, modern code coverage setup based on the approach used in `microsoft/vscode`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aab0ee8-578b-4ebc-b8db-a3ab8feecd73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0aab0ee8-578b-4ebc-b8db-a3ab8feecd73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

