### PR TITLE
Pull request size limit

### DIFF
--- a/.github/workflows/pr-size-limit.yml
+++ b/.github/workflows/pr-size-limit.yml
@@ -1,0 +1,64 @@
+name: PR Size Limit
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-size-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate PR size
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const maxChangedLines = 400;
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("Missing pull_request payload.");
+              return;
+            }
+
+            const additions = pr.additions ?? 0;
+            const deletions = pr.deletions ?? 0;
+            const total = additions + deletions;
+            const rationale = "https://smartbear.com/resources/case-studies/cisco-systems-collaborator/";
+
+            core.info(`PR additions: ${additions}, deletions: ${deletions}, total: ${total}`);
+
+            await core.summary
+              .addHeading("PR size check")
+              .addTable([
+                [
+                  { data: "Additions", header: true },
+                  { data: "Deletions", header: true },
+                  { data: "Total", header: true },
+                  { data: "Limit", header: true }
+                ],
+                [
+                  additions.toString(),
+                  deletions.toString(),
+                  total.toString(),
+                  maxChangedLines.toString()
+                ]
+              ])
+              .addRaw(`\nRationale for the 400-line limit: ${rationale}\n`)
+              .write();
+
+            if (total > maxChangedLines) {
+              core.warning(
+                `PR exceeds ${maxChangedLines} changed lines (${total}). ` +
+                  `Please split this PR into smaller, reviewable chunks. ` +
+                  `Rationale: ${rationale}`
+              );
+              core.setFailed(
+                `PR size ${total} > ${maxChangedLines}. Split the PR before merge.`
+              );
+            }

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Use TSLint with default settings.
 - `develop` is the main branch into which new features are merged. It is protected from direct pushes, so all changes come from pull requests.
 - Features: For all new additions, create a new feature branch. When complete, create a pull request into `develop` for that branch. Optionally, prefix feature branch names with `feature/`.
 
+### Pull request size
+
+Pull requests should stay at or below 400 changed lines (additions + deletions). If a change exceeds that size, split it into smaller, reviewable PRs. Rationale: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/
+
 ## Gratitude
 
 The original Org mode was written for Emacs by Carsten Dominik, with the help and support of [an impressive list of geniuses](http://orgmode.org/org.html#History-and-Acknowledgments). Our work is inspired by though not associated with their original masterpiece. In addition, many aspects of the extension were inspired by [the Spacemacs Org layer](https://github.com/syl20bnr/spacemacs/tree/master/layers/%2Bemacs/org).


### PR DESCRIPTION
Add a GitHub Actions workflow and update contributing guidelines to enforce a 400-line PR size limit, encouraging smaller, more reviewable pull requests.

The 400-line limit is based on research indicating that code review effectiveness decreases significantly for larger changes, as referenced in the Cisco Systems case study: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/. This workflow will fail PRs exceeding this limit, and can be configured as a required status check to prevent merging large PRs.

---
<a href="https://cursor.com/background-agent?bcId=bc-87829fe9-998a-4bdc-8a0c-b1b32ba84b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87829fe9-998a-4bdc-8a0c-b1b32ba84b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

