### PR TITLE
Add infra PR template with review guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -77,11 +77,13 @@ No only if existing users/workflows require zero changes.
 - Mitigation / rollout notes (if Yes):
 
 ## Verification
-<!-- How this was validated. Helps reviewers reproduce or trust checks. -->
+<!-- What evidence shows this change is safe and correct -->
 - [ ] CI passes
-- [ ] Manual checks (if needed):
-- [ ] Dry run or staging validation (if applicable)
-- Notes (commands, environments):
+- [ ] Manual checks
+- [ ] Dry run or staging validation
+
+### Verification Notes
+<!-- Commands, environments, URLs, logs -->
 
 ## Related Issues / PRs
 <!-- Connects decisions to prior context for future maintainers. -->

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -1,0 +1,22 @@
+## Infra PR テンプレート
+
+### 目的 / 背景
+
+### 変更内容
+- [ ] CI / Workflow
+- [ ] Build / Release
+- [ ] Coverage / Quality tools
+- [ ] Docs / Template / Repo settings
+- [ ] その他:
+
+### 影響範囲
+
+### 互換性 / Breaking change
+- [ ] あり
+- [ ] なし
+
+### 検証
+- [ ] CI が通ることを確認
+- [ ] 手動確認（必要な場合）:
+
+### 関連 Issue / PR

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -76,6 +76,7 @@ No only if existing users/workflows require zero changes.
 - [ ] Yes
 - [ ] No
 - Mitigation / rollout notes (if Yes):
+  <!-- e.g. staged rollout, backwards compatibility, migration steps, rollback plan -->
 
 ## Verification
 <!-- What evidence shows this change is safe and correct -->

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -28,7 +28,7 @@ the minimum context to assess safety, risk, and test coverage.
 If unsure, choose Yes.
 Yes if existing users or workflows must change, e.g.:
   - new required secrets/env/tools
-  - minimum version bumps
+  - minimum version bumps (e.g. Node.js 18+ required)
   - renamed/removed workflows or required config changes
 No only if existing users/workflows require zero changes.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -25,10 +25,12 @@ the minimum context to assess safety, risk, and test coverage.
 
 ### Breaking change
 <!--
+If unsure, choose Yes.
 Yes if existing users or workflows must change, e.g.:
   - new required secrets/env/tools
   - minimum version bumps
   - renamed/removed workflows or required config changes
+No only if existing users/workflows require zero changes.
 -->
 - [ ] Yes
 - [ ] No

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -1,8 +1,19 @@
 ## Infra PR Template
+<!--
+Why this structure:
+  - Purpose/Background explains intent and timing.
+  - Changes + Impacted Areas show scope and owners to involve.
+  - Compatibility highlights risk and rollout needs.
+  - Verification documents how correctness was checked.
+This reduces review back-and-forth for authors and gives reviewers
+the minimum context to assess safety, risk, and test coverage.
+-->
 
 ### Purpose / Background
+<!-- Why is this needed now? Link to incidents, upgrades, or goals. -->
 
 ### Changes
+<!-- Mark the relevant areas to guide reviewers and routing. -->
 - [ ] CI / Workflow
 - [ ] Build / Release
 - [ ] Coverage / Quality tools
@@ -10,13 +21,17 @@
 - [ ] Other:
 
 ### Impacted Areas
+<!-- List files, workflows, or systems affected (scope/blast radius). -->
 
 ### Compatibility / Breaking change
+<!-- Call out user-facing or workflow-breaking changes and mitigations. -->
 - [ ] Yes
 - [ ] No
 
 ### Verification
+<!-- How was this validated? Helps reviewers reproduce or trust checks. -->
 - [ ] CI passes
 - [ ] Manual checks (if needed):
 
 ### Related Issue / PR
+<!-- Connects decisions to prior context for future maintainers. -->

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -1,29 +1,58 @@
-## Infra PR Template
 <!--
-Why this structure:
-  - Purpose/Background explains intent and timing.
-  - Changes + Impacted Areas show scope and owners to involve.
-  - Compatibility highlights risk and rollout needs.
-  - Verification documents how correctness was checked.
-This reduces review back-and-forth for authors and gives reviewers
-the minimum context to assess safety, risk, and test coverage.
+This template is structured to match the reviewer's mental model
+and reduce review back-and-forth.
+
+Reviewer context (infra review order):
+1. Overview - what is changing and why
+2. Changes - which infra areas are touched
+3. Impacted Areas - scope/blast radius and owners
+4. Breaking Change - compatibility risks and migrations
+5. Verification - evidence of correctness
 -->
 
-### Purpose / Background
-<!-- Why is this needed now? Link to incidents, upgrades, or goals. -->
+<!--
+Why headers start at H2:
+- The PR title is treated as the H1 for the page, so template sections begin at H2.
+- GitHub style guide (Headers) states:
+  "Headers must adequately describe the content under them. Headers can either follow the guidelines for writing titles or can be written as questions. Use sentence casing for headers.
+  If an article has headers, the headers must start with an H2 level header. You can use H3 and H4 level headers to further organize content into related groups, but you cannot skip header levels. There must be text content between a header and subheader, such as an introduction."
+  Source: https://docs.github.com/en/enterprise-server@3.15/contributing/style-guide-and-content-model/style-guide?utm_source=chatgpt.com#headers
+-->
 
-### Changes
+<!--
+PR size policy:
+The max changed-lines limit is enforced by CI and defined in
+.github/workflows/pr-size-limit.yml (maxChangedLines).
+If an infra change requires more changes, split it into focused PRs
+and link them in the Related Issues / PRs section before requesting review.
+-->
+
+## Infra Overview
+<!--
+Required. In 1-3 short sentences (~200-400 characters), explain intent and timing.
+
+Include:
+- Why this change is needed (incident, upgrade, maintenance)
+- What will improve for developers/users
+- Any constraints or deadlines
+-->
+
+## Changes
 <!-- Mark the relevant areas to guide reviewers and routing. -->
 - [ ] CI / Workflow
 - [ ] Build / Release
 - [ ] Coverage / Quality tools
 - [ ] Docs / Template / Repo settings
 - [ ] Other:
+- Notes / links:
 
-### Impacted Areas
-<!-- List files, workflows, or systems affected (scope/blast radius). -->
+## Impacted Areas
+<!-- List files, workflows, services, or repos affected (scope/blast radius). -->
+- Files / workflows:
+- Systems / services:
+- Teams / owners (if applicable):
 
-### Breaking change
+## Breaking Change
 <!--
 If unsure, choose Yes.
 Yes if existing users or workflows must change, e.g.:
@@ -34,11 +63,18 @@ No only if existing users/workflows require zero changes.
 -->
 - [ ] Yes
 - [ ] No
+- Mitigation / rollout notes (if Yes):
 
-### Verification
-<!-- How was this validated? Helps reviewers reproduce or trust checks. -->
+## Verification
+<!-- How this was validated. Helps reviewers reproduce or trust checks. -->
 - [ ] CI passes
 - [ ] Manual checks (if needed):
+- [ ] Dry run or staging validation (if applicable)
+- Notes (commands, environments):
 
-### Related Issue / PR
+## Related Issues / PRs
 <!-- Connects decisions to prior context for future maintainers. -->
+- Issue:
+  - #
+- Related PRs:
+  - #

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -88,7 +88,7 @@ No only if existing users/workflows require zero changes.
 <!-- Commands, environments, URLs, logs -->
 
 ## Related Issues / PRs
-<!-- Connects decisions to prior context for future maintainers. -->
+<!-- Connects decisions to prior context for future maintainers. Write "None" if not applicable. -->
 - Issue:
   - #
 - Related PRs:

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -1,22 +1,22 @@
-## Infra PR テンプレート
+## Infra PR Template
 
-### 目的 / 背景
+### Purpose / Background
 
-### 変更内容
+### Changes
 - [ ] CI / Workflow
 - [ ] Build / Release
 - [ ] Coverage / Quality tools
 - [ ] Docs / Template / Repo settings
-- [ ] その他:
+- [ ] Other:
 
-### 影響範囲
+### Impacted Areas
 
-### 互換性 / Breaking change
-- [ ] あり
-- [ ] なし
+### Compatibility / Breaking change
+- [ ] Yes
+- [ ] No
 
-### 検証
-- [ ] CI が通ることを確認
-- [ ] 手動確認（必要な場合）:
+### Verification
+- [ ] CI passes
+- [ ] Manual checks (if needed):
 
-### 関連 Issue / PR
+### Related Issue / PR

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -23,8 +23,13 @@ the minimum context to assess safety, risk, and test coverage.
 ### Impacted Areas
 <!-- List files, workflows, or systems affected (scope/blast radius). -->
 
-### Compatibility / Breaking change
-<!-- Call out user-facing or workflow-breaking changes and mitigations. -->
+### Breaking change
+<!--
+Yes if existing users or workflows must change, e.g.:
+  - new required secrets/env/tools
+  - minimum version bumps
+  - renamed/removed workflows or required config changes
+-->
 - [ ] Yes
 - [ ] No
 

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -44,7 +44,9 @@ Include:
 - [ ] Coverage / Quality tools
 - [ ] Docs / Template / Repo settings
 - [ ] Other:
-- Notes / links:
+
+<!-- Optional: add brief context or links for the checked items -->
+Notes / links:
 
 ## Impacted Areas
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -39,6 +39,7 @@ Include:
 
 ## Changes
 <!-- Mark the relevant areas to guide reviewers and routing. -->
+<!-- Multiple selections are allowed. -->
 - [ ] CI / Workflow
 - [ ] Build / Release
 - [ ] Coverage / Quality tools

--- a/.github/PULL_REQUEST_TEMPLATE/infra.md
+++ b/.github/PULL_REQUEST_TEMPLATE/infra.md
@@ -47,7 +47,16 @@ Include:
 - Notes / links:
 
 ## Impacted Areas
-<!-- List files, workflows, services, or repos affected (scope/blast radius). -->
+<!--
+This section clarifies scope (where changes ripple).
+Infra changes often affect more than the diff suggests, so this helps reviewers
+decide who should be involved and what to scrutinize.
+
+Examples:
+- Files / workflows: changed files or CI workflows
+- Systems / services: Codecov, GitHub Actions, external SaaS
+- Teams / owners: relevant teams or maintainers (if any)
+-->
 - Files / workflows:
 - Systems / services:
 - Teams / owners (if applicable):


### PR DESCRIPTION
## Infra Overview
Add a dedicated infra PR template and align its structure with the existing bugfix template.
This improves review consistency and clarifies what information reviewers need for infra changes.
 
## Changes
- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:
 
Notes / links:
- New infra template: `.github/PULL_REQUEST_TEMPLATE/infra.md`
 
## Impacted Areas
- Files / workflows: `.github/PULL_REQUEST_TEMPLATE/infra.md`
- Systems / services: GitHub PR template rendering
- Teams / owners (if applicable): repo maintainers
 
## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):
  - N/A
 
## Verification
- [x] CI passes
- [ ] Manual checks
- [ ] Dry run or staging validation
 
### Verification Notes
No runtime changes; template-only update.
 
## Related Issues / PRs
- Issue:
  - None
- Related PRs:
  - None


---
<a href="https://cursor.com/background-agent?bcId=bc-8b3ce2b3-c00e-4ea0-889e-8028eb94b5b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b3ce2b3-c00e-4ea0-889e-8028eb94b5b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>