### PR TITLE
Add bugfix PR template and contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,4 +1,16 @@
 <!--
+This template is structured to match the reviewer’s mental model
+and reduce review back-and-forth.
+
+Reviewer context (bugfix review order):
+1. Overview – what is broken and what is affected
+2. Problem – what actually happened
+3. Reproduction – can it be reproduced
+4. Root Cause – why it happened
+5. Fix – whether the fix addresses the cause
+-->
+
+<!--
 Why headers start at H2:
 - The PR title is treated as the H1 for the page, so template sections begin at H2.
 - GitHub style guide (Headers) states:

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -19,6 +19,14 @@ Why headers start at H2:
   Source: https://docs.github.com/en/enterprise-server@3.15/contributing/style-guide-and-content-model/style-guide?utm_source=chatgpt.com#headers
 -->
 
+<!--
+PR size policy:
+The max changed-lines limit is enforced by CI and defined in
+.github/workflows/pr-size-limit.yml (maxChangedLines).
+If a bugfix requires more changes, split it into focused PRs
+and link them in the Related Issues / PRs section before requesting review.
+-->
+
 ## Bugfix Overview
 <!--
 Required. PRs without a meaningful overview may be sent back for clarification.

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -9,7 +9,7 @@ Why headers start at H2:
 
 ## Bugfix Overview
 <!--
-Summarize the fix in 1–2 lines.
+In 1-2 lines (~120 chars), describe the fixes included in this PR.
 Make it immediately clear what changed and what is now correct.
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -9,10 +9,27 @@ Why headers start at H2:
 
 ## Bugfix Overview
 <!--
-In 1-2 lines (~120 chars), describe the fixes included in this PR.
-Overview must describe the bug context and impact. Do not restate the PR title.
-Include why it is a bug, who/what is affected, and the expected behavior.
-Example: Fix date parsing so recurring tasks no longer shift by one day in UTC.
+Required. PRs without a meaningful overview may be sent back for clarification.
+
+In 1-3 short sentences, describe the bug context and impact.
+Do NOT restate the PR title.
+
+Include:
+- Under what conditions the bug occurred
+- What the observed behavior was
+- What the expected behavior should be
+
+Why this is a good example:
+- It explains why the behavior is considered a bug (not just what was changed)
+- It describes the observed vs expected behavior clearly
+- It narrows down the affected conditions, making the issue reproducible and reviewable
+- It provides enough context for reviewers without requiring them to infer intent from the diff
+
+Good example:
+Recurring tasks created near midnight were parsed using local time,
+causing them to shift by one day when evaluated in UTC.
+Tasks should always execute on the originally selected date regardless of timezone.
+Affects tasks scheduled between 23:00-00:00 local time.
 -->
 
 ## Problem

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -115,6 +115,12 @@ Scope and risk assessment
 
 ## Related Issues / PRs
 <!--
-Issue numbers or related PRs
+List related issues or PRs for context.
+
+Required if this bugfix is split across multiple PRs.
+For a single-PR fix, link the issue if applicable.
 -->
-- Fixes #
+- Issue:
+  - #
+- Related PRs:
+  - #

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -14,28 +14,27 @@ Required. PRs without a meaningful overview may be sent back for clarification.
 In 1-3 short sentences, describe the bug context and impact.
 Do NOT restate the PR title.
 
-Include:
-- Under what conditions the bug occurred
-- What the observed behavior was
-- What the expected behavior should be
-
-Why this is a good example:
-- It explains why the behavior is considered a bug (not just what was changed)
-- It describes the observed vs expected behavior clearly
-- It narrows down the affected conditions, making the issue reproducible and reviewable
-- It provides enough context for reviewers without requiring them to infer intent from the diff
-
 Good example:
 Recurring tasks created near midnight were parsed using local time,
 causing them to shift by one day when evaluated in UTC.
 Tasks should always execute on the originally selected date regardless of timezone.
 Affects tasks scheduled between 23:00-00:00 local time.
+
+Why this is a good example:
+- It explains why the behavior is considered a bug (not just what was changed)
+- It clearly describes observed vs expected behavior
+- It narrows down affected conditions, making the issue reproducible and reviewable
+- It provides enough context for reviewers without requiring them to infer intent from the diff
 -->
 
 ## Problem
 <!--
-- What was broken
-- What the user experienced
+Describe the problem in more detail from a user or system perspective.
+This section expands on the Overview.
+
+Include:
+- What was broken in practice
+- What the user or system actually experienced
 -->
 - Observed behavior:
 - Expected behavior:

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -23,7 +23,7 @@ Why headers start at H2:
 <!--
 Required. PRs without a meaningful overview may be sent back for clarification.
 
-In 1-3 short sentences (~100-200 characters), describe the bug context and impact.
+In 1-3 short sentences (~200-400 characters), describe the bug context and impact.
 Do NOT restate the PR title.
 
 Good example:

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -23,7 +23,7 @@ Why headers start at H2:
 <!--
 Required. PRs without a meaningful overview may be sent back for clarification.
 
-In 1-3 short sentences, describe the bug context and impact.
+In 1-3 short sentences (~100-200 characters), describe the bug context and impact.
 Do NOT restate the PR title.
 
 Good example:

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,3 +1,12 @@
+<!--
+Why headers start at H2:
+- The PR title is treated as the H1 for the page, so template sections begin at H2.
+- GitHub style guide (Headers) states:
+  "Headers must adequately describe the content under them. Headers can either follow the guidelines for writing titles or can be written as questions. Use sentence casing for headers.
+  If an article has headers, the headers must start with an H2 level header. You can use H3 and H4 level headers to further organize content into related groups, but you cannot skip header levels. There must be text content between a header and subheader, such as an introduction."
+  Source: https://docs.github.com/en/enterprise-server@3.15/contributing/style-guide-and-content-model/style-guide?utm_source=chatgpt.com#headers
+-->
+
 ## Bugfix Overview
 <!--
 Summarize the fix in 1–2 lines.

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,13 +1,13 @@
 <!--
-This template is structured to match the reviewer’s mental model
+This template is structured to match the reviewer's mental model
 and reduce review back-and-forth.
 
 Reviewer context (bugfix review order):
-1. Overview – what is broken and what is affected
-2. Problem – what actually happened
-3. Reproduction – can it be reproduced
-4. Root Cause – why it happened
-5. Fix – whether the fix addresses the cause
+1. Overview - what is broken and what is affected
+2. Problem - what actually happened
+3. Reproduction - can it be reproduced
+4. Root Cause - why it happened
+5. Fix - whether the fix addresses the cause
 -->
 
 <!--
@@ -25,6 +25,11 @@ Required. PRs without a meaningful overview may be sent back for clarification.
 
 In 1-3 short sentences (~200-400 characters), describe the bug context and impact.
 Do NOT restate the PR title.
+
+Include:
+- Under what conditions the bug occurred
+- What the observed behavior was
+- What the expected behavior should be
 
 Good example:
 Recurring tasks created near midnight were parsed using local time,

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -88,6 +88,7 @@ How you confirmed the fix is correct
 - [ ] Manual verification
 - [ ] Automated test added or updated
 - [ ] Existing tests pass
+- [ ] Screenshots or logs attached (if applicable)
 - Test notes (commands, environment, datasets):
 
 ## Impact / Risk

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -11,6 +11,7 @@ Why headers start at H2:
 <!--
 In 1-2 lines (~120 chars), describe the fixes included in this PR.
 Make it immediately clear what changed and what is now correct.
+Example: Fix date parsing so recurring tasks no longer shift by one day in UTC.
 -->
 
 ## Problem

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,62 @@
+## Bugfix Overview
+<!--
+Summarize the fix in 1–2 lines.
+Make it immediately clear what changed and what is now correct.
+-->
+
+## Problem
+<!--
+- What was broken
+- What the user experienced
+-->
+- Observed behavior:
+- Expected behavior:
+
+## Reproduction Steps
+<!--
+Minimum steps for reviewers to reproduce the issue.
+If reproduction is difficult, explain why.
+-->
+1.
+2.
+3.
+
+## Root Cause
+<!--
+- The underlying cause of the bug
+- Why it was not detected earlier
+-->
+- Cause:
+- Why it was missed:
+
+## Fix
+<!--
+- How the issue was fixed
+- Why this fix is sufficient
+-->
+- Fix approach:
+- Alternatives considered (if any):
+
+## Verification
+<!--
+How you confirmed the fix is correct
+-->
+- [ ] Manual verification
+- [ ] Automated test added or updated
+- [ ] Existing tests pass
+- Test notes (commands, environment, datasets):
+
+## Impact / Risk
+<!--
+Scope and risk assessment
+-->
+- Affected users:
+- Backward compatibility:
+- Potential side effects:
+- Mitigation or monitoring plan (if needed):
+
+## Related Issues / PRs
+<!--
+Issue numbers or related PRs
+-->
+- Fixes #

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -10,7 +10,8 @@ Why headers start at H2:
 ## Bugfix Overview
 <!--
 In 1-2 lines (~120 chars), describe the fixes included in this PR.
-Make it immediately clear what changed and what is now correct.
+Overview must describe the bug context and impact. Do not restate the PR title.
+Include why it is a bug, who/what is affected, and the expected behavior.
 Example: Fix date parsing so recurring tasks no longer shift by one day in UTC.
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -42,7 +42,7 @@ Include:
 ## Reproduction Steps
 <!--
 Minimum steps for reviewers to reproduce the issue.
-If reproduction is difficult, explain why.
+If reproduction is difficult or environment-specific, explain why.
 -->
 1.
 2.

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -50,16 +50,21 @@ If reproduction is difficult or environment-specific, explain why.
 
 ## Root Cause
 <!--
-- The underlying cause of the bug
-- Why it was not detected earlier
+Explain the underlying cause of the bug.
+Focus on design, assumptions, or missing constraints.
+
+Also explain why this issue was not detected earlier.
 -->
 - Cause:
 - Why it was missed:
 
 ## Fix
 <!--
-- How the issue was fixed
-- Why this fix is sufficient
+Describe how the issue was fixed and why this approach is sufficient.
+
+Mention:
+- Why this fix addresses the root cause
+- Why alternative approaches were not chosen (if applicable)
 -->
 - Fix approach:
 - Alternatives considered (if any):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ to reduce review back-and-forth and improve review quality.
 - Bugfix PRs must use the bugfix template.
 - Templates explain why information is required, not just what to write.
 
-See `.github/PULL_REQUEST_TEMPLATE/` for details.
+See https://github.com/hiroakit/vscode-org-mode/tree/develop/.github/PULL_REQUEST_TEMPLATE/ for details.
 
 ## Naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to VS Code Org Mode
+
+## Pull Request Guidelines
+
+- All changes must be submitted via pull requests.
+- PRs that exceed the max changed-lines limit enforced by CI are rejected. The limit is defined in `.github/workflows/pr-size-limit.yml`.
+- Large changes must be split into focused, reviewable PRs.
+
+## Pull Request Templates
+
+This repository uses purpose-specific PR templates
+to reduce review back-and-forth and improve review quality.
+
+- Bugfix PRs must use the bugfix template.
+- Templates explain why information is required, not just what to write.
+
+See `.github/PULL_REQUEST_TEMPLATE/` for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 - All changes must be submitted via pull requests.
 - PRs that exceed the max changed-lines limit enforced by CI are rejected. The limit is defined in `.github/workflows/pr-size-limit.yml`.
 - Large changes must be split into focused, reviewable PRs.
-- Bugfix branches must use the `bugfix/` prefix (e.g. `bugfix/short-description`).
+- Branch names must follow the Git Workflow section below.
 
 ## Review Process
 
@@ -43,6 +43,7 @@ Use ESLint with the repository configuration.
 - All changes come through pull requests; direct pushes are not expected.
 - For new additions, create a feature branch and open a pull request into `develop`.
 - Optionally, prefix feature branch names with `feature/`.
+- Bugfix branches must use the `bugfix/` prefix (e.g. `bugfix/short-description`).
 
 ## Pull Request Size
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Pull Request Guidelines
 
 - All changes must be submitted via pull requests.
-- PRs that exceed the max changed-lines limit enforced by CI are rejected. The limit is defined in `.github/workflows/pr-size-limit.yml`.
+- PRs that exceed the max changed-lines limit enforced by CI are rejected. The limit is defined in [.github/workflows/pr-size-limit.yml](https://github.com/hiroakit/vscode-org-mode/blob/develop/.github/workflows/pr-size-limit.yml).
 - Large changes must be split into focused, reviewable PRs.
 - Branch names must follow the Git Workflow section below.
 
@@ -21,7 +21,7 @@ to reduce review back-and-forth and improve review quality.
 - Bugfix PRs must use the bugfix template.
 - Templates explain why information is required, not just what to write.
 
-See https://github.com/hiroakit/vscode-org-mode/tree/develop/.github/PULL_REQUEST_TEMPLATE/ for details.
+See [PULL_REQUEST_TEMPLATE](https://github.com/hiroakit/vscode-org-mode/tree/develop/.github/PULL_REQUEST_TEMPLATE/) for details.
 
 ## Naming
 
@@ -47,6 +47,6 @@ Use ESLint with the repository configuration.
 
 ## Pull Request Size
 
-The max changed-lines limit is enforced by CI and defined in `.github/workflows/pr-size-limit.yml`.
+The max changed-lines limit is enforced by CI and defined in [.github/workflows/pr-size-limit.yml](https://github.com/hiroakit/vscode-org-mode/blob/develop/.github/workflows/pr-size-limit.yml).
 If a change exceeds that size, split it into smaller, reviewable PRs.
 Rationale: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 - PRs that exceed the max changed-lines limit enforced by CI are rejected. The limit is defined in `.github/workflows/pr-size-limit.yml`.
 - Large changes must be split into focused, reviewable PRs.
 
+## Review Process
+
+- PRs are reviewed by maintainers.
+- CI must pass before merge.
+- Reviewers may request changes or clarification.
+
 ## Pull Request Templates
 
 This repository uses purpose-specific PR templates
@@ -15,3 +21,30 @@ to reduce review back-and-forth and improve review quality.
 - Templates explain why information is required, not just what to write.
 
 See `.github/PULL_REQUEST_TEMPLATE/` for details.
+
+## Naming
+
+The full name of this project is `VS Code Org Mode`. It is abbreviated `vscode-org-mode`. In the VS Code Marketplace, it is listed as `Org Mode`.
+
+Commands are prefixed with `org.` and followed by camel case, eg `org.insertHeadingRespectContent`. Command titles are prefixed with `Org: ` and followed by capitalized words separated by spaces, eg `Org: Insert Heading Respect Content`.
+
+Filenames use kebab case, eg `header-functions.ts`.
+
+When referring to the original Org mode, we capitalize the "O" and leave the "m" lower case. This is in keeping with the original team's usage on [orgmode.org](http://orgmode.org/).
+
+## Code Style
+
+Use ESLint with the repository configuration.
+
+## Git Workflow
+
+- `develop` is the default branch for new changes.
+- All changes come through pull requests; direct pushes are not expected.
+- For new additions, create a feature branch and open a pull request into `develop`.
+- Optionally, prefix feature branch names with `feature/`.
+
+## Pull Request Size
+
+The max changed-lines limit is enforced by CI and defined in `.github/workflows/pr-size-limit.yml`.
+If a change exceeds that size, split it into smaller, reviewable PRs.
+Rationale: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - All changes must be submitted via pull requests.
 - PRs that exceed the max changed-lines limit enforced by CI are rejected. The limit is defined in `.github/workflows/pr-size-limit.yml`.
 - Large changes must be split into focused, reviewable PRs.
+- Bugfix branches must use the `bugfix/` prefix (e.g. `bugfix/short-description`).
 
 ## Review Process
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ We welcome pull requests.
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before submitting a pull request.
 It explains our PR guidelines, review process, and required templates.
+Details are centralized in CONTRIBUTING.md.
 
 ## Gratitude
 

--- a/README.md
+++ b/README.md
@@ -107,33 +107,10 @@ Detailed documentation is kept in the [GitHub Wiki](https://github.com/vscode-or
 
 ## Contributing
 
-We welcome contributions to the GitHub repo. Here are basic guidelines for conventions.
+We welcome issues, feature requests, and pull requests.
 
-Join the community [here](https://gitter.im/vscode-org-mode/Lobby).
-
-### Naming
-
-The full name of this project is `VS Code Org Mode`. It is abbreviated `vscode-org-mode`. In the VS Code Marketplace, it is listed as `Org Mode`.
-
-Commands are prefixed with `org.` and followed by camel case, eg `org.insertHeadingRespectContent`. Command titles are prefixed with `Org: ` and followed by capitalized words separated by spaces, eg `Org: Insert Heading Respect Content`.
-
-Filenames use kebab case, eg `header-functions.ts`.
-
-When referring to the original Org mode, we capitalize the "O" and leave the "m" lower case. This is in keeping with the original team's usage on [orgmode.org](http://orgmode.org/).
-
-### Code
-
-Use TSLint with default settings.
-
-### Git
-
-- `master` is used for production deploys.
-- `develop` is the main branch into which new features are merged. It is protected from direct pushes, so all changes come from pull requests.
-- Features: For all new additions, create a new feature branch. When complete, create a pull request into `develop` for that branch. Optionally, prefix feature branch names with `feature/`.
-
-### Pull request size
-
-Pull requests should stay at or below 400 changed lines (additions + deletions). If a change exceeds that size, split it into smaller, reviewable PRs. Rationale: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before submitting a pull request.
+It explains our PR guidelines, review process, and required templates.
 
 ## Gratitude
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Detailed documentation is kept in the [GitHub Wiki](https://github.com/vscode-or
 
 ## Contributing
 
-We welcome issues, feature requests, and pull requests.
+We welcome pull requests.
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before submitting a pull request.
 It explains our PR guidelines, review process, and required templates.


### PR DESCRIPTION
## Infra Overview
Standardizes contribution workflow by adding a bugfix PR template, a CONTRIBUTING guide, and a README pointer to those rules. Improves review consistency and reduces back-and-forth for maintenance changes. No runtime behavior changes.

## Changes
- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:

Notes / links:
- Added bugfix PR template and related guidance.
- Added CONTRIBUTING.md and README reference.
- Documented PR size policy source and branch naming rules.

## Impacted Areas
- Files / workflows: .github/PULL_REQUEST_TEMPLATE/bugfix.md, CONTRIBUTING.md, README.md
- Systems / services: GitHub PR templates / repo docs
- Teams / owners (if applicable): Maintainers

## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):

## Verification
- [ ] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation

### Verification Notes
- Reviewed templates and docs for accuracy.

## Related Issues / PRs
- Issue:
  - None
- Related PRs:
  - None