### PR TITLE
Require US English PR titles and descriptions

### DIFF
--- a/.cursor/rules/contributing.mdc
+++ b/.cursor/rules/contributing.mdc
@@ -1,9 +1,3 @@
 # Contribution guidelines (AI notice)
 
-Before making changes or drafting a PR, read:
-
-- CONTRIBUTING.md
-- The appropriate PR template in .github/PULL_REQUEST_TEMPLATE/
-
-Follow those documents for branch naming, PR structure, and review
-requirements. PR titles and descriptions must be written in US English.
+Primary AI guidance lives in AGENTS.md. Read it first.

--- a/.cursor/rules/contributing.mdc
+++ b/.cursor/rules/contributing.mdc
@@ -1,0 +1,9 @@
+# Contribution guidelines (AI notice)
+
+Before making changes or drafting a PR, read:
+
+- CONTRIBUTING.md
+- The appropriate PR template in .github/PULL_REQUEST_TEMPLATE/
+
+Follow those documents for branch naming, PR structure, and review
+requirements. PR titles and descriptions must be written in US English.

--- a/.cursor/rules/contributing.mdc
+++ b/.cursor/rules/contributing.mdc
@@ -1,3 +1,8 @@
+---
+description: "Directs agents to AGENTS.md for contribution and PR rules"
+alwaysApply: false
+---
+
 # Contribution guidelines (AI notice)
 
 Primary AI guidance lives in AGENTS.md. Read it first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent instructions
+
+Before making changes or drafting a PR, read:
+
+- CONTRIBUTING.md
+- The appropriate PR template in .github/PULL_REQUEST_TEMPLATE/
+
+Follow those documents for branch naming, PR structure, and review
+requirements. PR titles and descriptions must be written in US English.
+If guidance conflicts, CONTRIBUTING.md and the PR templates are the
+source of truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
   - Bugfix PRs must use the bugfix template.
   - Infra PRs must use the infra template.
   - Templates explain why information is required, not just what to write.
+- Write PR titles and descriptions in US English.
 - Keep PRs within the max changed-lines limit enforced by CI and defined in [.github/workflows/pr-size-limit.yml](https://github.com/hiroakit/vscode-org-mode/blob/develop/.github/workflows/pr-size-limit.yml).
   If a change exceeds that size, split it into smaller, reviewable PRs.
   Rationale: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/


### PR DESCRIPTION
## Infra Overview
This change clarifies PR language expectations and improves agent guidance by pointing to AGENTS.md and adding rule metadata for Cursor.

## Changes
- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:

Notes / links:
- Updated CONTRIBUTING.md to require US English PR titles/descriptions.
- Added .cursor/rules/contributing.mdc to reference CONTRIBUTING.md and PR templates.
- Added AGENTS.md as the primary entry point for contributor and PR rules.
- Updated .cursor/rules/contributing.mdc to point to AGENTS.md and include rule metadata (description, alwaysApply: false).

## Impacted Areas
- Files / workflows: CONTRIBUTING.md, .cursor/rules/contributing.mdc
- Systems / services: None
- Teams / owners (if applicable): None

## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):

## Verification
- [x] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation

### Verification Notes
- Not run (docs-only change).

## Related Issues / PRs
- Issue:
  - None
- Related PRs:
  - None