### PR TITLE
Codecov カバレッジ設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,12 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
-      - name: Publish coverage
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: npm run publish-coverage
+      - name: Upload coverage reports to Codecov
+        if: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
 
       - name: Build extension
         run: npm run vscode:prepublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,12 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: coverage/lcov.info
 
       - name: Build extension

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![Ratings](https://vsmarketplacebadges.dev/rating/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![CI](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml/badge.svg)](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml)
-[![codecov](https://img.shields.io/codecov/c/github/vscode-org-mode/vscode-org-mode?branch=master)](https://codecov.io/gh/vscode-org-mode/vscode-org-mode)
+[![codecov](https://img.shields.io/codecov/c/github/hiroakit/vscode-org-mode?branch=develop)](https://app.codecov.io/github/hiroakit/vscode-org-mode)
 [![License](https://img.shields.io/github/license/vscode-org-mode/vscode-org-mode)](./LICENSE.txt)
 
 :warning: The publisher name was changed, **tootone/org-mode has become vscode-org-mode/org-mode** :warning:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![Ratings](https://vsmarketplacebadges.dev/rating/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![CI](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml/badge.svg)](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml)
-[![codecov](https://img.shields.io/codecov/c/github/hiroakit/vscode-org-mode?branch=develop)](https://app.codecov.io/github/hiroakit/vscode-org-mode)
+[![codecov](https://img.shields.io/codecov/c/github/hiroakit/vscode-org-mode?branch=main)](https://app.codecov.io/github/hiroakit/vscode-org-mode)
 [![License](https://img.shields.io/github/license/vscode-org-mode/vscode-org-mode)](./LICENSE.txt)
 
 :warning: The publisher name was changed, **tootone/org-mode has become vscode-org-mode/org-mode** :warning:

--- a/scripts/upload-codecov.js
+++ b/scripts/upload-codecov.js
@@ -1,5 +1,9 @@
 const { createWriteStream, chmodSync, unlinkSync } = require('fs'), https = require('https'), os = require('os'), path = require('path'), { spawnSync } = require('child_process');
 const platform = { linux: 'linux', darwin: 'macos', win32: 'windows' }[process.platform];
+if (!process.env.CODECOV_TOKEN) {
+    console.log('CODECOV_TOKEN is not set; skipping Codecov upload.');
+    process.exit(0);
+}
 if (!platform) { console.error(`Unsupported platform: ${process.platform}`); process.exit(1); }
 const isWin = process.platform === 'win32';
 const bin = isWin ? 'codecov.exe' : 'codecov';


### PR DESCRIPTION
## Infra Overview
This PR updates the Codecov coverage upload mechanism in CI to use `codecov/codecov-action@v5` and adds a safeguard to prevent uploads when the `CODECOV_TOKEN` secret is not configured, improving CI robustness and security.

## Changes
- [x] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [ ] Docs / Template / Repo settings
- [x] Other: Script for Codecov upload

Notes / links:
Updated `scripts/upload-codecov.js` to also check for `CODECOV_TOKEN`.

## Impacted Areas
- Files / workflows: `.github/workflows/ci.yml`, `scripts/upload-codecov.js`
- Systems / services: GitHub Actions, Codecov
- Teams / owners (if applicable): Development/Infra team

## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):

## Verification
- [x] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation

### Verification Notes
- CI workflow will now only attempt Codecov upload if `secrets.CODECOV_TOKEN` is present and not empty.
- `scripts/upload-codecov.js` will exit gracefully if `process.env.CODECOV_TOKEN` is not set. This can be tested locally by running `npm run publish-coverage` with and without the `CODECOV_TOKEN` environment variable.

## Related Issues / PRs
- Issue: None
- Related PRs: None

---
<a href="https://cursor.com/background-agent?bcId=bc-219a61eb-a52b-4d5a-942f-79a62548a3f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-219a61eb-a52b-4d5a-942f-79a62548a3f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

