### PR TITLE
Configure Codecov uploads, comments, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,12 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
-      - name: Publish coverage
-        if: matrix.os == 'ubuntu-latest'
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: npm run publish-coverage
+      - name: Upload coverage reports to Codecov
+        if: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
 
       - name: Build extension
         run: npm run vscode:prepublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,12 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.os == 'ubuntu-latest' && secrets.CODECOV_TOKEN != '' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: coverage/lcov.info
 
       - name: Build extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,11 @@
 - CI must pass before merge.
 - Reviewers may request changes or clarification.
 
+## Coverage reporting
+
+We use Codecov (https://app.codecov.io/github/hiroakit/vscode-org-mode) to report code coverage in pull requests.
+Coverage reports are informational only and do not block CI.
+
 ## Naming
 
 The full name of this project is `VS Code Org Mode`. It is abbreviated `vscode-org-mode`. In the VS Code Marketplace, it is listed as `Org Mode`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![Ratings](https://vsmarketplacebadges.dev/rating/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![CI](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml/badge.svg)](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml)
-[![codecov](https://img.shields.io/codecov/c/github/vscode-org-mode/vscode-org-mode?branch=master)](https://codecov.io/gh/vscode-org-mode/vscode-org-mode)
+[![codecov](https://img.shields.io/codecov/c/github/hiroakit/vscode-org-mode?branch=develop)](https://app.codecov.io/github/hiroakit/vscode-org-mode)
 [![License](https://img.shields.io/github/license/vscode-org-mode/vscode-org-mode)](./LICENSE.txt)
 
 :warning: The publisher name was changed, **tootone/org-mode has become vscode-org-mode/org-mode** :warning:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![Ratings](https://vsmarketplacebadges.dev/rating/vscode-org-mode.org-mode.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-org-mode.org-mode)
 [![CI](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml/badge.svg)](https://github.com/hiroakit/vscode-org-mode/actions/workflows/ci.yml)
-[![codecov](https://img.shields.io/codecov/c/github/hiroakit/vscode-org-mode?branch=develop)](https://app.codecov.io/github/hiroakit/vscode-org-mode)
+[![codecov](https://img.shields.io/codecov/c/github/hiroakit/vscode-org-mode?branch=main)](https://app.codecov.io/github/hiroakit/vscode-org-mode)
 [![License](https://img.shields.io/github/license/vscode-org-mode/vscode-org-mode)](./LICENSE.txt)
 
 :warning: The publisher name was changed, **tootone/org-mode has become vscode-org-mode/org-mode** :warning:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,15 @@
 codecov:
   require_ci_to_pass: true
 
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 comment:
   layout: "reach, diff, flags, files"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,5 +13,5 @@ coverage:
 comment:
   layout: "reach, diff, flags, files"
   behavior: default
-  require_changes: true
+  require_changes: false
   after_n_builds: 1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+  after_n_builds: 1

--- a/scripts/upload-codecov.js
+++ b/scripts/upload-codecov.js
@@ -1,5 +1,9 @@
 const { createWriteStream, chmodSync, unlinkSync } = require('fs'), https = require('https'), os = require('os'), path = require('path'), { spawnSync } = require('child_process');
 const platform = { linux: 'linux', darwin: 'macos', win32: 'windows' }[process.platform];
+if (!process.env.CODECOV_TOKEN) {
+    console.log('CODECOV_TOKEN is not set; skipping Codecov upload.');
+    process.exit(0);
+}
 if (!platform) { console.error(`Unsupported platform: ${process.platform}`); process.exit(1); }
 const isWin = process.platform === 'win32';
 const bin = isWin ? 'codecov.exe' : 'codecov';


### PR DESCRIPTION
## Infra Overview
Align Codecov integration with https://app.codecov.io/github/hiroakit/vscode-org-mode, ensure uploads are guarded by CODECOV_TOKEN, and document coverage reporting behavior.
 
## Changes
- [x] CI / Workflow
- [ ] Build / Release
- [x] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:
Notes / links: Use Codecov Action v5 with an explicit token guard, add Codecov config for PR comments and informational status checks, update README badge to main branch, and document coverage reporting in CONTRIBUTING.md.
 
## Impacted Areas
- Files / workflows:
  - .github/workflows/ci.yml
  - scripts/upload-codecov.js
  - codecov.yml
  - README.md
  - CONTRIBUTING.md
- Systems / services:
  - GitHub Actions
  - Codecov (https://app.codecov.io/github/hiroakit/vscode-org-mode)
  - shields.io (badge)
- Teams / owners (if applicable):
  - N/A
 
## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):
 
## Verification
- [x] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation
 
### Verification Notes
- Not run locally; CI will validate on PR.
- Codecov comment https://github.com/hiroakit/vscode-org-mode/pull/26#issuecomment-3817668907
 
## Related Issues / PRs
- Issue:
  - None
- Related PRs:
  - None