### PR TITLE
Add *.vsix to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 *.orig
 
 *.old
+*.vsix


### PR DESCRIPTION
## Infra Overview

Add `*.vsix` pattern to `.gitignore` to prevent accidentally committing VSIX package files generated during extension builds. This prevents build artifacts from being tracked in the repository and reduces the risk of accidentally including large binary files in commits.

## Changes

- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:

Notes / links:
- Updated `.gitignore` to exclude VSIX package files

## Impacted Areas

- Files / workflows: `.gitignore`
- Systems / services: None
- Teams / owners (if applicable): None

## Breaking Change

- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):
  N/A

## Verification

- [x] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation

### Verification Notes

- Verified that `*.vsix` pattern correctly ignores VSIX files
- Confirmed existing `.gitignore` patterns remain intact
- Tested with `org-mode-1.1.0-SNAPSHOT.vsix` file (now ignored)

## Related Issues / PRs

- Issue:
  - None
- Related PRs:
  - None
