### PR TITLE
Add VSIX package build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,18 @@
+# Build Instructions
+
+This document describes how to build the VS Code Org Mode extension and create VSIX packages.
+
+## Creating VSIX Packages
+
+To create and install a VSIX package:
+
+```bash
+npm ci                                    # Install dependencies
+npm install -g @vscode/vsce              # Install vsce (first time only)
+vsce package                              # Create VSIX package
+code --install-extension org-mode-x.y.z.vsix  # Install in VS Code
+```
+
+The VSIX file name is based on the version in `package.json` (e.g., `org-mode-1.1.0-SNAPSHOT.vsix`).
+
+**Note**: `vsce package` automatically compiles TypeScript, so you don't need to run `npm run compile` separately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ When referring to the original Org mode, we capitalize the "O" and leave the "m"
 
 Use ESLint with the repository configuration.
 
+## Building the extension
+
+To create a VSIX package or build the extension locally, see [BUILD.md](BUILD.md).
+
 ## Git Workflow
 
 - `develop` is the default branch for new changes.


### PR DESCRIPTION
## Infra Overview
This change documents the exact steps to build and install a VSIX package for VS Code Org Mode, addressing gaps when contributors need a local package for testing or distribution. It also links the new BUILD.md from CONTRIBUTING so the instructions are discoverable during onboarding.
 
## Changes
- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:
 
Notes / links:
- Added BUILD.md with VSIX packaging steps.
- Linked BUILD.md from CONTRIBUTING.md for discoverability.
 
## Impacted Areas
- Files / workflows: BUILD.md, CONTRIBUTING.md
- Systems / services: None (documentation-only).
- Teams / owners (if applicable): Maintainers.
 
## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes): N/A
 
## Verification
Evidence gathered for this change:
- [ ] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation
 
### Verification Notes
- Docs-only change; no automated checks run.
 