### PR TITLE
Remove date-fns from extension bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,17 @@
 .vscode/**
 .vscode-test/**
+.github/**
+.cursor/**
+.node-version
+.nvmrc
+.vscode-test.mjs
+codecov.yml
+coverconfig.json
+eslint.config.cjs
+scripts/**
+AGENTS.md
+BUILD.md
+CONTRIBUTING.md
 node_modules/**
 out/test/**
 test/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 .vscode/**
 .vscode-test/**
+node_modules/**
 out/test/**
 test/**
 src/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "org-mode",
             "version": "1.1.0-SNAPSHOT",
             "license": "GPL-3.0-or-later",
-            "dependencies": {
-                "date-fns": "^1.28.3"
-            },
             "devDependencies": {
                 "@eslint/eslintrc": "^3.3.3",
                 "@eslint/js": "^9.39.2",
@@ -26,7 +23,7 @@
                 "typescript": "^5.4.3"
             },
             "engines": {
-                "node": ">=18.20.4",
+                "node": ">=24.12.0",
                 "npm": ">=8",
                 "vscode": "^1.87.0"
             }
@@ -521,6 +518,7 @@
             "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.54.0",
                 "@typescript-eslint/types": "8.54.0",
@@ -777,6 +775,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1118,11 +1117,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/date-fns": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-            "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
-        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1227,6 +1221,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2627,6 +2622,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2678,6 +2674,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
             "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -281,9 +281,6 @@
         "mocha": "^11.7.5",
         "typescript": "^5.4.3"
     },
-    "dependencies": {
-        "date-fns": "^1.28.3"
-    },
     "overrides": {
         "brace-expansion@^1.0.0": "1.1.12",
         "brace-expansion@^2.0.0": "2.0.2",

--- a/src/simple-datetime.ts
+++ b/src/simple-datetime.ts
@@ -1,4 +1,3 @@
-import * as datefns from 'date-fns';
 import * as Utils from './utils';
 
 const weekdayArray = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -118,9 +117,8 @@ export function currentDateTime(): ISimpleDateTime {
 
 export function modifyDate(dateString: string, action: string): string {
     const oldDate = parseDate(dateString);
-    const initialDateObject = datefns.parse(`${oldDate.year}-${oldDate.month}-${oldDate.day}`);
-
-    const dateObject = (action === "UP") ? datefns.addDays(initialDateObject, 1): datefns.addDays(initialDateObject, -1);
+    const initialDateObject = new Date(oldDate.year, oldDate.month - 1, oldDate.day);
+    const dateObject = addDays(initialDateObject, action === "UP" ? 1 : -1);
 
     const newDate = dateToSimpleDate(dateObject);
     if (!oldDate.weekday) {
@@ -128,6 +126,12 @@ export function modifyDate(dateString: string, action: string): string {
     }
 
     return buildDateString(newDate);
+}
+
+function addDays(date: Date, days: number): Date {
+    const nextDate = new Date(date.getTime());
+    nextDate.setDate(nextDate.getDate() + days);
+    return nextDate;
 }
 
 export function getClockTotal(line) {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -15,12 +15,12 @@ import * as simpleDatetime from '../src/simple-datetime';
 
 async function withLeftZero(enabled: boolean, action: () => Promise<void>) {
     const config = vscode.workspace.getConfiguration("org");
-    const previous = config.inspect<boolean>("addLeftZero")?.workspaceValue;
-    await config.update("addLeftZero", enabled, vscode.ConfigurationTarget.Workspace);
+    const previous = config.inspect<boolean>("addLeftZero")?.globalValue;
+    await config.update("addLeftZero", enabled, vscode.ConfigurationTarget.Global);
     try {
         await action();
     } finally {
-        await config.update("addLeftZero", previous, vscode.ConfigurationTarget.Workspace);
+        await config.update("addLeftZero", previous, vscode.ConfigurationTarget.Global);
     }
 }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -11,6 +11,18 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 
 import * as utils from '../src/utils';
+import * as simpleDatetime from '../src/simple-datetime';
+
+async function withLeftZero(enabled: boolean, action: () => Promise<void>) {
+    const config = vscode.workspace.getConfiguration("org");
+    const previous = config.inspect<boolean>("addLeftZero")?.workspaceValue;
+    await config.update("addLeftZero", enabled, vscode.ConfigurationTarget.Workspace);
+    try {
+        await action();
+    } finally {
+        await config.update("addLeftZero", previous, vscode.ConfigurationTarget.Workspace);
+    }
+}
 
 
 // Defines a Mocha test suite to group tests of similar kind together
@@ -22,5 +34,67 @@ suite("Extension Tests", () => {
         const headerPrefix = utils.getHeaderPrefix('*** Header');
 
         assert.equal(headerPrefix, expected);
+    });
+});
+
+suite("Simple datetime", () => {
+    test("parseDate parses weekday when present", async () => {
+        const parsedWithWeekday = simpleDatetime.parseDate("[2024-1-2 Tue]");
+        assert.deepStrictEqual(parsedWithWeekday, {
+            year: 2024,
+            month: 1,
+            day: 2,
+            weekday: "Tue",
+        });
+
+        const parsedWithoutWeekday = simpleDatetime.parseDate("[2024-1-2]");
+        assert.deepStrictEqual(parsedWithoutWeekday, {
+            year: 2024,
+            month: 1,
+            day: 2,
+            weekday: undefined,
+        });
+    });
+
+    test("buildDateString respects left zero setting", async () => {
+        const date = { year: 2024, month: 1, day: 2, weekday: "Tue" };
+        await withLeftZero(false, async () => {
+            assert.equal(simpleDatetime.buildDateString(date), "[2024-1-2 Tue]");
+        });
+        await withLeftZero(true, async () => {
+            assert.equal(simpleDatetime.buildDateString(date), "[2024-01-02 Tue]");
+        });
+    });
+
+    test("buildDateTimeString pads date and time", async () => {
+        const dateTime = {
+            year: 2024,
+            month: 1,
+            day: 2,
+            weekday: "Tue",
+            hours: 3,
+            minutes: 4,
+        };
+        await withLeftZero(true, async () => {
+            assert.equal(simpleDatetime.buildDateTimeString(dateTime), "[2024-01-02 Tue 03:04]");
+        });
+    });
+
+    test("modifyDate adjusts by one day", async () => {
+        await withLeftZero(false, async () => {
+            assert.equal(simpleDatetime.modifyDate("[2024-1-2 Tue]", "UP"), "[2024-1-3 Wed]");
+            assert.equal(simpleDatetime.modifyDate("[2024-1-2 Tue]", "DOWN"), "[2024-1-1 Mon]");
+            assert.equal(simpleDatetime.modifyDate("[2024-1-2]", "UP"), "[2024-1-3]");
+        });
+    });
+
+    test("getClockTotal handles ranges and padding", async () => {
+        await withLeftZero(false, async () => {
+            assert.equal(simpleDatetime.getClockTotal("CLOCK: 10:05--11:45"), "1:40");
+        });
+        await withLeftZero(true, async () => {
+            assert.equal(simpleDatetime.getClockTotal("CLOCK: 10:05--11:45"), "01:40");
+        });
+        assert.equal(simpleDatetime.getClockTotal("CLOCK: 10:05"), "");
     });
 });


### PR DESCRIPTION
## Infra Overview
This change removes the `date-fns` dependency and keeps the VSIX bundle lean to eliminate `vsce package` warnings. The extension only needs simple local date math today, so native `Date` APIs are sufficient and reduce packaged files without altering behavior.

## Changes
- [ ] CI / Workflow
- [x] Build / Release
- [ ] Coverage / Quality tools
- [ ] Docs / Template / Repo settings
- [x] Other: Extension packaging (vsce)

Notes / links:
- Removed `date-fns` usage in `simple-datetime.ts` and used native `Date` math.
- Added `node_modules/**`, .github/, .cursor/, scripts/, config files, contributor docs to `.vscodeignore` to prevent accidental bundling.
  - Kept docs/ and images/ to preserve Marketplace rendering.
- Background research:
  - No repository commit message or MVP doc explains the original `date-fns` choice.
  - Org manual notes the timestamp format is ISO 8601–inspired (Timestamps footnote).
  - Mailing list has a proposed timezone syntax (not yet implemented), which includes offsets and `@TZ` names. That proposal is not covered by `date-fns` alone.
    - Proposal: https://list.orgmode.org/87tu063ox2.fsf@localhost/
    - Follow-up guidance: https://list.orgmode.org/87v7oob78g.fsf@localhost/

## Impacted Areas
- Files / workflows: `.vscodeignore`, `package.json`, `package-lock.json`, `src/simple-datetime.ts`
- Systems / services: VSCE packaging / Marketplace bundle output
- Teams / owners (if applicable): Maintainers

## Breaking Change
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):

## Verification
- [x] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation

### Verification Notes

- ✅ npm ci
- ✅ npm test
- ✅ npx @vscode/vsce package

## Related Issues / PRs
- Issue:
  - #
- Related PRs:
  - #