### PR TITLE
Add GitHub label operations and guidelines

### DIFF
--- a/.github/labels.md
+++ b/.github/labels.md
@@ -1,30 +1,27 @@
-# GitHub Label Operations
+# GitHub Labels (Simple)
 
 ## Goals
 - Keep triage consistent and fast.
-- Route work to the right owners.
-- Make priority and scope obvious at a glance.
-- Support reporting and release planning.
+- Make priority and ownership obvious.
+- Keep the label set small.
 
-## Naming and hygiene rules
+## Naming rules
 - Use lowercase and hyphens.
-- Use a single prefix per label group: `type:`, `area:`, `priority:`, `status:`, `size:`.
-- Avoid duplicates or near-synonyms. Prefer one label per axis.
-- Do not repurpose labels. If a label changes meaning, create a new one.
+- One prefix per group: `type:`, `area:`, `priority:`, `status:`.
+- One label per group.
+- Do not repurpose labels. Create a new one if meaning changes.
 
 ## Required labeling
 
 ### Issues
 - Exactly one `type:` label.
+- Exactly one `area:` label.
 - Exactly one `priority:` label.
 - Exactly one `status:` label.
-- At least one `area:` label (use `area:extension` if unclear).
-- Optional: `size:` once the scope is known.
 
 ### Pull requests
 - Exactly one `type:` label.
 - At least one `area:` label.
-- Exactly one `size:` label.
 - Optional: `priority:` and `status:` labels.
 
 ## Label catalog
@@ -34,19 +31,13 @@
 | --- | --- | --- |
 | type:bug | #D73A4A | Something is broken or regressed. |
 | type:feature | #1D76DB | New user-visible behavior. |
-| type:enhancement | #A2EEEF | Improvements to existing behavior. |
 | type:docs | #0075CA | Documentation-only changes or requests. |
-| type:test | #C2E0C6 | Test additions, fixes, or refactors. |
 | type:maintenance | #F9D0C4 | Refactors, cleanup, tooling, or chores. |
 
 ### Area labels
 | Label | Color | Use when |
 | --- | --- | --- |
 | area:extension | #0E8A16 | General extension behavior or commands. |
-| area:outline-folding | #0E8A16 | Outline view, folding, navigation. |
-| area:syntax-highlighting | #0E8A16 | Grammar, tokens, or syntax colors. |
-| area:todo | #0E8A16 | TODO keyword handling and cycling. |
-| area:timestamps | #0E8A16 | Date/time parsing, formatting, or commands. |
 | area:docs | #0E8A16 | README, docs, or wiki-related changes. |
 | area:tests | #0E8A16 | Unit/integration tests. |
 | area:ci | #0E8A16 | CI workflows or automation. |
@@ -59,25 +50,15 @@
 | priority:p0 | #B60205 | Data loss, security issue, or crash. |
 | priority:p1 | #D93F0B | Major feature broken or severe regression. |
 | priority:p2 | #FBCA04 | Default priority for normal work. |
-| priority:p3 | #FEF2C0 | Nice-to-have or low urgency. |
 
 ### Status labels
 | Label | Color | Use when |
 | --- | --- | --- |
 | status:needs-triage | #C5DEF5 | New issue awaiting initial triage. |
 | status:needs-info | #BFDADC | Reporter must provide more details. |
-| status:blocked | #B60205 | Blocked by external dependency or decision. |
 | status:in-progress | #5319E7 | Actively being worked on. |
+| status:blocked | #B60205 | Blocked by external dependency or decision. |
 | status:ready | #0E8A16 | Ready to pick up or to implement. |
-
-### Size labels
-| Label | Color | Use when |
-| --- | --- | --- |
-| size:xs | #BFDADC | 1-10 lines changed. |
-| size:s | #BFDADC | 11-50 lines changed. |
-| size:m | #BFDADC | 51-150 lines changed. |
-| size:l | #BFDADC | 151-300 lines changed. |
-| size:xl | #BFDADC | 301-400 lines changed (max). |
 
 ### Special labels (unprefixed)
 | Label | Color | Use when |
@@ -87,12 +68,10 @@
 
 ## Triage workflow
 1. New issue arrives with `status:needs-triage`.
-2. Add `type:` and `area:` labels.
-3. Assign `priority:` based on impact.
-4. Set `status:` to `ready`, `needs-info`, or `blocked`.
-5. Add `size:` once the scope is understood.
+2. Add `type:`, `area:`, and `priority:`.
+3. Set `status:` to `ready`, `needs-info`, or `blocked`.
+4. Set `status:in-progress` when work starts.
 
 ## Label lifecycle
-- Add a label only when it has a clear, lasting use case.
-- Update this document whenever the label set changes.
-- Remove unused labels during quarterly cleanup.
+- Keep the list minimal and stable.
+- Update this document whenever labels change.

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -1,4 +1,4 @@
-# GitHub Labels (Simple)
+# GitHub Labels
 
 ## Goals
 - Keep triage consistent and fast.

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -16,8 +16,8 @@
 ### Issues
 - Exactly one `type:` label.
 - Exactly one `area:` label.
-- Exactly one `priority:` label.
 - Exactly one `status:` label.
+- Add a `priority:` label only when it is higher or lower than normal.
 
 ### Pull requests
 - Exactly one `type:` label.
@@ -49,7 +49,7 @@
 | --- | --- | --- |
 | priority:p0 | #B60205 | Data loss, security issue, or crash. |
 | priority:p1 | #D93F0B | Major feature broken or severe regression. |
-| priority:p2 | #FBCA04 | Default priority for normal work. |
+| priority:p3 | #FEF2C0 | Nice-to-have or low urgency. |
 
 ### Status labels
 | Label | Color | Use when |
@@ -68,9 +68,10 @@
 
 ## Triage workflow
 1. New issue arrives with `status:needs-triage`.
-2. Add `type:`, `area:`, and `priority:`.
-3. Set `status:` to `ready`, `needs-info`, or `blocked`.
-4. Set `status:in-progress` when work starts.
+2. Add `type:` and `area:`.
+3. Add `priority:` only if it is p0, p1, or p3.
+4. Set `status:` to `ready`, `needs-info`, or `blocked`.
+5. Set `status:in-progress` when work starts.
 
 ## Label lifecycle
 - Keep the list minimal and stable.

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -33,6 +33,7 @@
 | type:feature | #1D76DB | New user-visible behavior. |
 | type:docs | #0075CA | Documentation-only changes or requests. |
 | type:maintenance | #F9D0C4 | Refactors, cleanup, tooling, or chores. |
+| type:planning | #BFDADC | Iteration planning or roadmap work. |
 
 ### Area labels
 | Label | Color | Use when |

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -66,6 +66,7 @@ Priority is not always determined by the reporter.
 ### Special labels (unprefixed)
 | Label | Color | Use when |
 | --- | --- | --- |
+| duplicate | #CFD3D7 | This issue or pull request already exists. |
 | good first issue | #7057FF | Suitable for first-time contributors. |
 | help wanted | #008672 | Maintainers want external help. |
 

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -46,6 +46,8 @@
 | area:dependencies | #0E8A16 | Dependency updates. |
 
 ### Priority labels
+Normal priority items intentionally have no label to keep triage fast.
+Priority is not always determined by the reporter.
 | Label | Color | Use when |
 | --- | --- | --- |
 | priority:p0 | #B60205 | Data loss, security issue, or crash. |

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -29,11 +29,14 @@
 ### Type labels
 | Label | Color | Use when |
 | --- | --- | --- |
-| type:bug | #D73A4A | Something is broken or regressed. |
-| type:feature | #1D76DB | New user-visible behavior. |
-| type:docs | #0075CA | Documentation-only changes or requests. |
-| type:maintenance | #F9D0C4 | Refactors, cleanup, tooling, or chores. |
-| type:planning | #BFDADC | Iteration planning or roadmap work. |
+| type:bug | #0075CA | Something is broken or regressed. |
+| type:feature | #0075CA | New or improved user-visible behavior. |
+| type:infra | #0075CA | Infrastructure and codebase maintenance (not user-visible). |
+| type:planning | #0075CA | Sprint or iteration planning; use with `area:docs` only. |
+
+#### Notes
+- `type:infra` covers: tooling, CI, workflows, repository governance (e.g. labels, templates), information infrastructure (e.g. knowledge base, wikis), and refactors or code cleanup with no user-visible behavior change.
+- For documentation-only changes, use `type:bug` (fixing errors), `type:feature` (new or improved user-facing docs), or `type:infra` (doc infrastructure); use `area:docs` for scope.
 
 ### Area labels
 | Label | Color | Use when |
@@ -45,32 +48,53 @@
 | area:release | #0E8A16 | Changelog or publishing. |
 | area:dependencies | #0E8A16 | Dependency updates. |
 
+#### Notes
+- Use `type:bug` when a dependency causes a defect, security issue, or regression; use `type:infra` for routine updates, lockfile changes, or policy work.
+- A PR labeled with `area:docs` only is treated as a documentation-only change.
+
 ### Priority labels
-Normal priority items intentionally have no label to keep triage fast.
-Priority is not always determined by the reporter.
 | Label | Color | Use when |
 | --- | --- | --- |
-| priority:p0 | #B60205 | Data loss, security issue, or crash. |
-| priority:p1 | #D93F0B | Major feature broken or severe regression. |
+| priority:p0 | #FEF2C0 | Data loss, security issue, or crash. |
+| priority:p1 | #FEF2C0 | Major feature broken or severe regression. |
 | priority:p3 | #FEF2C0 | Nice-to-have or low urgency. |
+
+#### Notes
+- Normal priority items intentionally have no label to keep triage fast.
+- Priority is not always determined by the reporter.
 
 ### Status labels
 | Label | Color | Use when |
 | --- | --- | --- |
 | status:needs-triage | #C5DEF5 | New issue awaiting initial triage. |
-| status:needs-info | #BFDADC | Reporter must provide more details. |
-| status:in-progress | #5319E7 | Actively being worked on. |
-| status:blocked | #B60205 | Blocked by external dependency or decision. |
-| status:ready | #0E8A16 | Ready to pick up or to implement. |
+| status:needs-info | #C5DEF5 | Reporter must provide more details. |
+| status:in-progress | #C5DEF5 | Actively being worked on. |
+| status:blocked | #C5DEF5 | Blocked by external dependency or decision. |
+| status:ready | #C5DEF5 | Ready to pick up or to implement. |
 
 ### Special labels (unprefixed)
 | Label | Color | Use when |
 | --- | --- | --- |
-| duplicate | #CFD3D7 | This issue or pull request already exists. |
+| duplicate | #7057FF | This issue or pull request already exists. |
 | good first issue | #7057FF | Suitable for first-time contributors. |
-| help wanted | #008672 | Maintainers want external help. |
+| help wanted | #7057FF | Maintainers want external help. |
+
+## Label examples for pull requests
+
+| Case | type | area |
+| --- | --- | --- |
+| Adding a new feature to the VSCode extension | type:feature | area:core, area:tests |
+| Improving the VSCode extension | type:feature | area:core, area:tests |
+| Feature or improvement with documentation updates | type:feature | area:core, area:docs |
+| Fixing a bug in the VSCode extension (code and tests) | type:bug | area:core, area:tests |
+| Fixing a bug and updating docs in the same PR | type:bug | area:core, area:docs (and area:tests if applicable) |
+| Fixing an error or gap in documentation only | type:bug | area:docs |
+| PR only expands test code | type:infra | area:tests |
+| Repository operations or governance (e.g. labels, triage, templates) | type:infra | area:docs (or area:ci etc. by scope) |
 
 ## Triage workflow
+This workflow applies to issues only. Pull requests are expected to have `type:` and `area:` set at creation time; `status:` is optional on pull requests.
+
 1. New issue arrives with `status:needs-triage`.
 2. Add `type:` and `area:`.
 3. Add `priority:` only if it is p0, p1, or p3.

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -38,7 +38,7 @@
 ### Area labels
 | Label | Color | Use when |
 | --- | --- | --- |
-| area:extension | #0E8A16 | General extension behavior or commands. |
+| area:core | #0E8A16 | Core extension behavior or commands. |
 | area:docs | #0E8A16 | README, docs, or wiki-related changes. |
 | area:tests | #0E8A16 | Unit/integration tests. |
 | area:ci | #0E8A16 | CI workflows or automation. |

--- a/.github/labels.md
+++ b/.github/labels.md
@@ -1,0 +1,98 @@
+# GitHub Label Operations
+
+## Goals
+- Keep triage consistent and fast.
+- Route work to the right owners.
+- Make priority and scope obvious at a glance.
+- Support reporting and release planning.
+
+## Naming and hygiene rules
+- Use lowercase and hyphens.
+- Use a single prefix per label group: `type:`, `area:`, `priority:`, `status:`, `size:`.
+- Avoid duplicates or near-synonyms. Prefer one label per axis.
+- Do not repurpose labels. If a label changes meaning, create a new one.
+
+## Required labeling
+
+### Issues
+- Exactly one `type:` label.
+- Exactly one `priority:` label.
+- Exactly one `status:` label.
+- At least one `area:` label (use `area:extension` if unclear).
+- Optional: `size:` once the scope is known.
+
+### Pull requests
+- Exactly one `type:` label.
+- At least one `area:` label.
+- Exactly one `size:` label.
+- Optional: `priority:` and `status:` labels.
+
+## Label catalog
+
+### Type labels
+| Label | Color | Use when |
+| --- | --- | --- |
+| type:bug | #D73A4A | Something is broken or regressed. |
+| type:feature | #1D76DB | New user-visible behavior. |
+| type:enhancement | #A2EEEF | Improvements to existing behavior. |
+| type:docs | #0075CA | Documentation-only changes or requests. |
+| type:test | #C2E0C6 | Test additions, fixes, or refactors. |
+| type:maintenance | #F9D0C4 | Refactors, cleanup, tooling, or chores. |
+
+### Area labels
+| Label | Color | Use when |
+| --- | --- | --- |
+| area:extension | #0E8A16 | General extension behavior or commands. |
+| area:outline-folding | #0E8A16 | Outline view, folding, navigation. |
+| area:syntax-highlighting | #0E8A16 | Grammar, tokens, or syntax colors. |
+| area:todo | #0E8A16 | TODO keyword handling and cycling. |
+| area:timestamps | #0E8A16 | Date/time parsing, formatting, or commands. |
+| area:docs | #0E8A16 | README, docs, or wiki-related changes. |
+| area:tests | #0E8A16 | Unit/integration tests. |
+| area:ci | #0E8A16 | CI workflows or automation. |
+| area:release | #0E8A16 | Changelog or publishing. |
+| area:dependencies | #0E8A16 | Dependency updates. |
+
+### Priority labels
+| Label | Color | Use when |
+| --- | --- | --- |
+| priority:p0 | #B60205 | Data loss, security issue, or crash. |
+| priority:p1 | #D93F0B | Major feature broken or severe regression. |
+| priority:p2 | #FBCA04 | Default priority for normal work. |
+| priority:p3 | #FEF2C0 | Nice-to-have or low urgency. |
+
+### Status labels
+| Label | Color | Use when |
+| --- | --- | --- |
+| status:needs-triage | #C5DEF5 | New issue awaiting initial triage. |
+| status:needs-info | #BFDADC | Reporter must provide more details. |
+| status:blocked | #B60205 | Blocked by external dependency or decision. |
+| status:in-progress | #5319E7 | Actively being worked on. |
+| status:ready | #0E8A16 | Ready to pick up or to implement. |
+
+### Size labels
+| Label | Color | Use when |
+| --- | --- | --- |
+| size:xs | #BFDADC | 1-10 lines changed. |
+| size:s | #BFDADC | 11-50 lines changed. |
+| size:m | #BFDADC | 51-150 lines changed. |
+| size:l | #BFDADC | 151-300 lines changed. |
+| size:xl | #BFDADC | 301-400 lines changed (max). |
+
+### Special labels (unprefixed)
+| Label | Color | Use when |
+| --- | --- | --- |
+| good first issue | #7057FF | Suitable for first-time contributors. |
+| help wanted | #008672 | Maintainers want external help. |
+
+## Triage workflow
+1. New issue arrives with `status:needs-triage`.
+2. Add `type:` and `area:` labels.
+3. Assign `priority:` based on impact.
+4. Set `status:` to `ready`, `needs-info`, or `blocked`.
+5. Add `size:` once the scope is understood.
+
+## Label lifecycle
+- Add a label only when it has a clear, lasting use case.
+- Update this document whenever the label set changes.
+- Remove unused labels during quarterly cleanup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,12 @@
   If a change exceeds that size, split it into smaller, reviewable PRs.
   Rationale: https://smartbear.com/resources/case-studies/cisco-systems-collaborator/
 
+## Issue triage and labels
+
+We maintain a label taxonomy for consistent triage and routing.
+See [.github/labels.md](./.github/labels.md) for the full label catalog
+and usage rules.
+
 ## Review Process
 
 - PRs are reviewed by maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,5 @@ To create a VSIX package or build the extension locally, see [BUILD.md](BUILD.md
 - Optionally, prefix feature branch names with `feature/`.
 - Bugfix branches must use the `bugfix/` prefix (e.g. `bugfix/short-description`).
 - Infra branches must use the `infra/` prefix (e.g. `infra/short-description`).
+  - Use `infra/` for repo or process work such as docs, CI, tooling,
+    templates, release automation, or dependency maintenance.


### PR DESCRIPTION
<!--
This template is structured to match the reviewer's mental model
and reduce review back-and-forth.

Reviewer context (infra review order):
1. Overview - what is changing and why
2. Changes - which infra areas are touched
3. Impacted Areas - scope/blast radius and owners
4. Breaking Change - compatibility risks and migrations
5. Verification - evidence of correctness
-->

<!--
Why headers start at H2:
- The PR title is treated as the H1 for the page, so template sections begin at H2.
- GitHub style guide (Headers) states:
  "Headers must adequately describe the content under them. Headers can either follow the guidelines for writing titles or can be written as questions. Use sentence casing for headers.
  If an article has headers, the headers must start with an H2 level header. You can use H3 and H4 level headers to further organize content into related groups, but you cannot skip header levels. There must be text content between a header and subheader, such as an introduction."
  Source: https://docs.github.com/en/enterprise-server@3.15/contributing/style-guide-and-content-model/style-guide?utm_source=chatgpt.com#headers
-->

<!--
PR size policy:
The max changed-lines limit is enforced by CI and defined in
.github/workflows/pr-size-limit.yml (maxChangedLines).
If an infra change requires more changes, split it into focused PRs
and link them in the Related Issues / PRs section before requesting review.
-->

## Infra Overview
<!--
Required. In 1-3 short sentences (~200-400 characters), explain intent and timing.

Include:
- Why this change is needed (incident, upgrade, maintenance)
- What will improve for developers/users
- Any constraints or deadlines
-->

This PR establishes the GitHub label strategy for this repository from scratch.

It introduces four label groups with consistent prefixes — `type:`, `area:`, `priority:`, and `status:` — and documents the rules for how labels are applied to issues and pull requests. The guide includes a triage workflow for issues and a table of PR labeling examples to help contributors apply labels correctly.

## Changes
<!-- Mark the relevant areas to guide reviewers and routing. -->
<!-- Multiple selections are allowed. -->
- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:

<!-- Optional: add brief context or links for the checked items -->
Notes / links:
Labels applied at merge time: `type:infra`, `area:docs`.

## Impacted Areas
<!--
This section clarifies scope (where changes ripple).
Infra changes often affect more than the diff suggests, so this helps reviewers
decide who should be involved and what to scrutinize.

- Files / workflows: `.github/labels.md`, `CONTRIBUTING.md`, `AGENTS.md`
- Systems / services: GitHub Labels (label catalog documentation only; no automated label sync)
- Teams / owners (if applicable): maintainers

## Breaking Change
<!--
If unsure, choose Yes.
Yes if existing users or workflows must change, e.g.:
  - new required secrets/env/tools
  - minimum version bumps (e.g. Node.js 18+ required)
  - renamed/removed workflows or required config changes
No only if existing users/workflows require zero changes.
-->
- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):
  <!-- e.g. staged rollout, backwards compatibility, migration steps, rollback plan -->

## Verification
<!-- What evidence shows this change is safe and correct -->
- [x] CI passes
- [ ] Manual checks
- [ ] Dry run or staging validation

### Verification Notes
<!-- Commands, environments, URLs, logs -->

No functionality code changes; no manual verification necessary.

## Related Issues / PRs

- Issue: None
- Related PRs: None