### PR TITLE
Add to include completion criteria in planning section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,6 @@ Follow those documents for branch naming, PR structure, and review
 requirements. PR titles and descriptions must be written in US English.
 If guidance conflicts, CONTRIBUTING.md and the PR templates are the
 source of truth.
+
+When creating a plan, include a section that defines completion
+criteria.


### PR DESCRIPTION
## Infra Overview

`AGENTS.md` lacks guidance on what constitutes a completed plan, making it difficult to verify that agent-generated plans are actionable and done. This change adds a requirement for agents to include a completion criteria section in every plan they produce.

## Changes

- [ ] CI / Workflow
- [ ] Build / Release
- [ ] Coverage / Quality tools
- [x] Docs / Template / Repo settings
- [ ] Other:

Notes / links:

## Impacted Areas

- Files / workflows: `AGENTS.md`
- Systems / services: N/A
- Teams / owners (if applicable): N/A

## Breaking Change

- [ ] Yes
- [x] No
- Mitigation / rollout notes (if Yes):

## Verification

- [ ] CI passes
- [x] Manual checks
- [ ] Dry run or staging validation

### Verification Notes

Confirmed that `AGENTS.md` contains the added completion criteria requirement.

## Related Issues / PRs

- Issue:
  - None
- Related PRs:
  - None
