### PR TITLE
Fix TODO keyword switching for Unicode keywords

### DIFF
--- a/src/cursor-context.ts
+++ b/src/cursor-context.ts
@@ -35,13 +35,25 @@ export default function getCursorContext(_textEditor: TextEditor, _edit: TextEdi
     }
 
     // Match for TODO (or absence)
-    const todoKeywords = Util.getKeywords().join("|");
-    // const todoWords = "TODO|DONE";
-    const todoHeaderRegexp = new RegExp(`^(\\s*\\*+\\s+)(${todoKeywords})(?:\\b|\\[|$)`);
-    match = todoHeaderRegexp.exec(curLine);
+    const keywords = Util.getKeywords();
+    const todoKeywords = keywords.filter((k) => k !== "").join("|");
+
+    // For keyword matching, avoid `\b` because JS word boundaries are ASCII-based and
+    // don't work for non-ASCII keywords (e.g. CJK). Instead require a delimiter that
+    // we expect after a TODO keyword in a heading.
+    if (todoKeywords) {
+        const todoHeaderRegexp = new RegExp(`^(\\s*\\*+\\s+)(${todoKeywords})(?=\\s|\\[|$)`);
+        match = todoHeaderRegexp.exec(curLine);
+        if (match) {
+            return getTodoContext(match, cursorPos);
+        }
+    }
+
+    // If this is a heading without a keyword, treat it as the empty TODO keyword context.
+    const headerPrefixRegexp = /^(\s*\*+\s+)/;
+    match = headerPrefixRegexp.exec(curLine);
     if (match) {
-        // We've found our match
-        return getTodoContext(match, cursorPos);
+        return getEmptyTodoContext(match, cursorPos);
     }
 
     return undefined;
@@ -79,6 +91,21 @@ function getTodoContext(match: RegExpExecArray, cursorPos: Position): IContextDa
 
     return {
         data: todoWord,
+        dataLabel: TODO,
+        line,
+        range
+    };
+}
+
+function getEmptyTodoContext(match: RegExpExecArray, cursorPos: Position): IContextData {
+    const line = cursorPos.line;
+
+    const start = match.index + match[1].length;
+    const pos = new Position(line, start);
+    const range = new Range(pos, pos);
+
+    return {
+        data: "",
         dataLabel: TODO,
         line,
         range

--- a/src/modify-context.ts
+++ b/src/modify-context.ts
@@ -23,11 +23,15 @@ function modifyContext(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdi
         } case TODO: {
             const newTodoString = nextTodo(ctx.data, action);
             if (newTodoString === "") {
-                // Must remove extra space
+                // Remove a single trailing space after the TODO keyword (if present).
+                // Do not remove other delimiters like `[` that may follow the keyword.
                 const oldEnd = ctx.range.end;
-                const newEnd = oldEnd.with({ character: oldEnd.character + 1 });
-                const oldRange = ctx.range;
-                ctx.range = oldRange.with({ end: newEnd });
+                const lineText = textEditor.document.lineAt(ctx.line).text;
+                if (oldEnd.character < lineText.length && lineText[oldEnd.character] === " ") {
+                    const newEnd = oldEnd.with({ character: oldEnd.character + 1 });
+                    const oldRange = ctx.range;
+                    ctx.range = oldRange.with({ end: newEnd });
+                }
             }
             edit.replace(ctx.range, newTodoString);
             break;

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -11,6 +11,7 @@ type TestEditorAction = (editor: vscode.TextEditor, document: vscode.TextDocumen
 async function inTextEditor(options: TestEditorOptions, action: TestEditorAction) {
     const d = await vscode.workspace.openTextDocument(options);
     await vscode.window.showTextDocument(d);
+    await vscode.extensions.getExtension('vscode-org-mode.org-mode')?.activate();
     await action(vscode.window.activeTextEditor!, d);
 }
 

--- a/test/todo-unicode.test.ts
+++ b/test/todo-unicode.test.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+interface TestEditorOptions {
+    language?: string;
+    content?: string;
+}
+
+type TestEditorAction = (editor: vscode.TextEditor, document: vscode.TextDocument) => void;
+
+async function inTextEditor(options: TestEditorOptions, action: TestEditorAction) {
+    const d = await vscode.workspace.openTextDocument(options);
+    await vscode.window.showTextDocument(d);
+    await vscode.extensions.getExtension('vscode-org-mode.org-mode')?.activate();
+    await action(vscode.window.activeTextEditor!, d);
+}
+
+async function withTodoKeywords<T>(keywords: string[], action: () => Thenable<T>) {
+    const config = vscode.workspace.getConfiguration('org');
+    const original = config.get<string[]>('todoKeywords');
+    try {
+        await config.update('todoKeywords', keywords, vscode.ConfigurationTarget.Global);
+        return await action();
+    } finally {
+        await config.update('todoKeywords', original, vscode.ConfigurationTarget.Global);
+    }
+}
+
+suite('Todo switching (unicode)', () => {
+    test('IncrementContext cycles unicode keywords', async () => {
+        const steps = [
+            '* Header',
+            '* 待办 Header',
+            '* 完成 Header',
+            '* Header',
+        ];
+
+        await withTodoKeywords(['待办', '完成'], () =>
+            inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
+                for (let i = 1; i < steps.length; ++i) {
+                    await vscode.commands.executeCommand('org.incrementContext');
+                    assert.equal(document.getText(), steps[i]);
+                }
+            })
+        );
+    });
+
+    test('DecrementContext cycles unicode keywords', async () => {
+        const steps = [
+            '* 完成 Header',
+            '* 待办 Header',
+            '* Header',
+            '* 完成 Header',
+        ];
+
+        await withTodoKeywords(['待办', '完成'], () =>
+            inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
+                for (let i = 1; i < steps.length; ++i) {
+                    await vscode.commands.executeCommand('org.decrementContext');
+                    assert.equal(document.getText(), steps[i]);
+                }
+            })
+        );
+    });
+});
+

--- a/test/todo-unicode.test.ts
+++ b/test/todo-unicode.test.ts
@@ -62,5 +62,86 @@ suite('Todo switching (unicode)', () => {
             })
         );
     });
+
+    test('Matches keyword before bracket with no space', async () => {
+        const steps = [
+            '* 待办[#A] Header',
+            '* 完成[#A] Header',
+            '* [#A] Header',
+        ];
+
+        await withTodoKeywords(['待办', '完成'], () =>
+            inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
+                for (let i = 1; i < steps.length; ++i) {
+                    await vscode.commands.executeCommand('org.incrementContext');
+                    assert.equal(document.getText(), steps[i]);
+                }
+            })
+        );
+    });
+
+    test('Matches keyword at end-of-line', async () => {
+        const steps = [
+            '* 待办',
+            '* 完成',
+            '* ',
+        ];
+
+        await withTodoKeywords(['待办', '完成'], () =>
+            inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
+                for (let i = 1; i < steps.length; ++i) {
+                    await vscode.commands.executeCommand('org.incrementContext');
+                    assert.equal(document.getText(), steps[i]);
+                }
+            })
+        );
+    });
+
+    test('Japanese keywords (3+) cycle and preserve empty state', async () => {
+        const steps = [
+            '* Header',
+            '* やる Header',
+            '* 完了 Header',
+            '* 保留 Header',
+            '* Header',
+        ];
+
+        await withTodoKeywords(['やる', '完了', '保留'], () =>
+            inTextEditor({ language: 'org', content: steps[0] }, async (_, document) => {
+                for (let i = 1; i < steps.length; ++i) {
+                    await vscode.commands.executeCommand('org.incrementContext');
+                    assert.equal(document.getText(), steps[i]);
+                }
+            })
+        );
+    });
+
+    test('Hangul keywords cycle in both directions', async () => {
+        const incSteps = [
+            '* Header',
+            '* 해야함 Header',
+            '* 완료 Header',
+            '* Header',
+        ];
+        const decSteps = [
+            '* Header',
+            '* 완료 Header',
+            '* 해야함 Header',
+            '* Header',
+        ];
+
+        await withTodoKeywords(['해야함', '완료'], () =>
+            inTextEditor({ language: 'org', content: incSteps[0] }, async (_, document) => {
+                for (let i = 1; i < incSteps.length; ++i) {
+                    await vscode.commands.executeCommand('org.incrementContext');
+                    assert.equal(document.getText(), incSteps[i]);
+                }
+                for (let i = 1; i < decSteps.length; ++i) {
+                    await vscode.commands.executeCommand('org.decrementContext');
+                    assert.equal(document.getText(), decSteps[i]);
+                }
+            })
+        );
+    });
 });
 


### PR DESCRIPTION
## Bugfix Overview
TODO keyword switching failed when TODO keywords contained non-ASCII characters (e.g., CJK/Hangul), because the heading matcher relied on an ASCII word-boundary check.
This PR updates TODO detection to use an explicit delimiter check and adds regression tests to cover Unicode keywords.

## Problem
- Observed behavior:
  - With Unicode TODO keywords configured, `org.incrementContext` / `org.decrementContext` does not recognize the TODO context in headings, so switching does nothing (or becomes inconsistent).
- Expected behavior:
  - Headings should be recognized as TODO context and cycle through configured TODO keywords regardless of whether the keywords are ASCII or Unicode.

## Reproduction Steps
1. Set `org.todoKeywords` to Unicode keywords (example: `["待办", "完成"]`).
2. Create an Org heading like `* Header`.
3. Run `Org: Increment Context` (or press the bound key).
4. Expected: `* 待办 Header` -> `* 完成 Header` -> `* Header` (cycle). Observed (before): no switch / inconsistent switching.

## Root Cause
- Cause:
  - The TODO heading regex used `\b` to detect keyword boundaries. In JS regex, `\b` is ASCII word-boundary based (`[A-Za-z0-9_]`) and does not work reliably for non-ASCII keywords.
- Why it was missed:
  - Existing tests only covered ASCII keywords (`TODO`, `DONE`) and did not include Unicode TODO keywords.

## Fix
- Fix approach:
  - Replace the `\b` boundary check with a lookahead for expected delimiters after a TODO keyword (`\s`, `[`, or end-of-line).
  - Preserve “no keyword” behavior by treating any heading (`* ...`) as the empty TODO keyword context and cycling into the first configured keyword.
  - Add regression tests that set Unicode `org.todoKeywords` and validate increment/decrement cycling.
- Alternatives considered (if any):
  - Expanding the regex with hard-coded Unicode ranges. Rejected because it does not scale across scripts and is easy to get wrong.

## Verification
- [ ] Manual verification
- [x] Automated test added or updated
- [x] Existing tests pass
- [ ] Screenshots or logs attached (if applicable)
- Test notes (commands, environment, datasets):
  - ✅ npm run compile
  - ✅ npm run lint
  - ✅ npm test

## Impact / Risk
- Affected users:
  - Users configuring `org.todoKeywords` with Unicode keywords (Japanese/Chinese/Korean, etc.).
- Backward compatibility:
  - No breaking changes expected; ASCII keywords continue to work.
- Potential side effects:
  - Low risk; regex matching behavior is now based on explicit delimiters rather than `\b`.
- Mitigation or monitoring plan (if needed):
  - Covered by new regression tests for Unicode keyword cycling.

## Related Issues / PRs
- Issue:
  - https://github.com/vscode-org-mode/vscode-org-mode/issues/137
- Related PRs:
  - None