### PR TITLE
Fix outline crash on empty heading with trailing space

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,9 @@ export function getHeaderPrefix(line: string) {
  * @return the title name
  */
 export function getHeaderTitle(line: string): string {
-    return line.substr(line.indexOf(' ') + 1);
+    const rawTitle = line.substring(line.indexOf(' ') + 1);
+    const title = rawTitle.trim();
+    return title.length > 0 ? title : '(empty heading)';
 }
 
 export function getPrefix(line: string) {

--- a/test/outline.test.ts
+++ b/test/outline.test.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+
+interface TestEditorOptions {
+    language?: string;
+    content?: string;
+}
+
+type TestEditorAction = (editor: vscode.TextEditor, document: vscode.TextDocument) => Promise<void> | void;
+
+async function inTextEditor(options: TestEditorOptions, action: TestEditorAction) {
+    const d = await vscode.workspace.openTextDocument(options);
+    await vscode.window.showTextDocument(d);
+    await action(vscode.window.activeTextEditor!, d);
+}
+
+suite('Outline', () => {
+    test('Document symbols should not break on empty heading with trailing space', async () => {
+        const ext = vscode.extensions.getExtension('vscode-org-mode.org-mode');
+        await ext?.activate();
+
+        const content =
+            '* Top level\n' +
+            '** Sub level\n' +
+            '** Next subheading is empty without a trailing space\n' +
+            '**\n' +
+            '** Next has a trailing space\n' +
+            '** \n' +
+            '** This heading should still be shown in outline\n' +
+            '* And this one too\n';
+
+        await inTextEditor({ language: 'org', content }, async (_, document) => {
+            const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                'vscode.executeDocumentSymbolProvider',
+                document.uri
+            );
+
+            assert.ok(Array.isArray(symbols), 'Expected symbols array');
+            const collectNames = (items: vscode.DocumentSymbol[]): string[] => {
+                const names: string[] = [];
+                for (const s of items) {
+                    names.push(s.name);
+                    if (s.children?.length) {
+                        names.push(...collectNames(s.children));
+                    }
+                }
+                return names;
+            };
+            const names = collectNames(symbols);
+
+            assert.ok(names.includes('Top level'));
+            assert.ok(names.includes('Sub level'));
+            assert.ok(names.includes('This heading should still be shown in outline'));
+            assert.ok(names.includes('And this one too'));
+        });
+    });
+});
+


### PR DESCRIPTION
## Bugfix Overview
Outline generation could crash when an Org heading line is empty but contains a trailing space (e.g. `** `), causing the Outline view to show only partial results or “No symbols found in document”. The outline should remain functional and include subsequent headings even when empty headings exist.

## Problem
- Observed behavior:
  - Documents containing an empty heading with a trailing space (e.g. `** `) can break symbol generation.
  - VS Code logs show `name must not be falsy`, and headings after the problematic line are missing from the Outline.
- Expected behavior:
  - Outline generation should not crash on empty headings; it should continue and show subsequent headings.

## Reproduction Steps
1. Open an `.org` document containing a heading like `** ` (asterisks + space only).
2. Open the Outline view.
3. Observe missing headings after that line and/or “No symbols found in document”, with `name must not be falsy` in the console.

## Root Cause
- `utils.getHeaderTitle()` could return an empty string for headings like `** `.
- `OrgFoldingAndOutlineDocumentState` passes that title to `SymbolInformation`, and VS Code rejects falsy symbol names, throwing `name must not be falsy` and interrupting symbol computation.
- Why it was missed:
  - Existing tests did not exercise the Outline symbol provider path with empty headings.

## Fix
- Fix approach:
  - Ensure `getHeaderTitle()` never returns an empty string by falling back to a placeholder (`(empty heading)`) when the extracted title is blank after trimming.
- Alternatives considered:
  - Skipping empty headings (would hide structure from Outline).
  - Handling it only in the outline provider (would duplicate title-normalization logic).

## Verification
- [x] Automated test added or updated
- [x] Existing tests pass
- Test notes:
  - `npm test`
  - Added `test/outline.test.ts` to validate that `vscode.executeDocumentSymbolProvider` does not break on `** ` and that subsequent headings are still present.

## Impact / Risk
- Affected users:
  - Anyone editing Org documents that contain empty headings with trailing spaces.
- Backward compatibility:
  - Low risk. Only affects the displayed name for empty headings in Outline.
- Potential side effects:
  - Empty headings will appear as `(empty heading)` in Outline instead of being blank (which previously crashed).

## Related Issues / PRs
- Issue:
  - vscode-org-mode/vscode-org-mode#218